### PR TITLE
MAST Metadata Schema

### DIFF
--- a/ukaea-schema/experiment/mast/diagnostics/signal.schema.json
+++ b/ukaea-schema/experiment/mast/diagnostics/signal.schema.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "urn:ukaea:experiment:mast:signal-schema",
+    "description": "Metadata to describe signals captured from a diagnostic",
+    "type": "object",
+    "required": [ "shot_id", "quality", "shape", "units", "description", "signal_type", "dimensions"],
+    "properties": {
+        "shot_id": {
+            "type": "int",
+            "description": "ID of the shot this signal was produced by.",
+        },
+        "quality": {
+            "type": "enum[string]",
+            "description": "Quality flag for this signal."
+        },
+        "shape": {
+            "type": "array[int]",
+            "description": "Shape of each dimension of this signal. e.g. [10, 100, 3]"
+        },
+        "units": {
+            "type": "string",
+            "description": "The units of data contained within this dataset."
+        },
+        "decription": {
+            "type": "string",
+            "description": "The description of this signal."
+        },
+        "signal_type": {
+            "type": "enum[string]",
+            "description": "The type of the signal dataset. e.g. 'Raw', 'Analysed'"
+        },
+        "dimensions": {
+            "type": "array[string]",
+            "description": "The dimension names of the dataset, in order. e.g. ['time', 'radius']"
+        },
+        "image_subclass": {
+            "type": "enum[string]",
+            "description": "The subclass for this image data. e.g. 'IMAGE_INDEXED'"
+        },
+        "image_format": {
+            "type": "enum[string]",
+            "description": "The format the image was original recorded in. e.g. IPX"
+        }
+    }
+}

--- a/ukaea-schema/experiment/mast/diagnostics/source.schema.json
+++ b/ukaea-schema/experiment/mast/diagnostics/source.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "urn:ukaea:experiment:mast:source-schema",
+    "description": "Metadata to describe from diagnostic sources",
+    "type": "object",
+    "required": [ "name", "description", "source_type"],
+    "properties": {
+        "name": {
+            "type": "string",
+            "example": "Short name of the source"
+        },
+        "description": {
+            "type": "string",
+            "example": "Description of the data captured from this source."
+        },
+        "source_type": {
+            "type": "enum[string]",
+            "example": "The type of this source e.g. 'Analysed'"
+
+        }
+    }
+}

--- a/ukaea-schema/experiment/mast/mast.schema.json
+++ b/ukaea-schema/experiment/mast/mast.schema.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "urn:ukaea:experiment:mast-schema",
+    "description": "MAST scientific metadata schema",
+    "type": "object",
+    "required": ["shot_id", "timestamp", "campaign", "facility"],
+    "properties": {
+        "shot_id": {
+            "type": "int",
+            "description": "Unique number identifying this shot"
+        },
+        "timestamp": {
+            "type": "timestamp",
+            "description": "Time the shot was fired in ISO 8601 format. e.g. '2023‐08‐10T09:51:19+00:00'"
+        },
+        "preshot_description": {
+            "type": "string",
+            "description": "A description by the investigator of the experiment before the shot was fired."
+        },
+        "postshot_description": {
+            "type": "string",
+            "description": "A description by the investigator of the experiment after the shot was fired."
+        },
+        "campaign": {
+            "type": "enum[str]",
+            "description": "A description by the investigator of the experiment after the shot was fired."
+        },
+        "reference_shot": {
+            "type": "int",
+            "description": "Unique number identifying the reference shot used by this shot."
+        },
+        "scenario": {
+            "type": "enum[string]",
+            "description": "The scenario used for this shot."
+        },
+        "heating": {
+            "type": "enum[string]",
+            "description": "The type of heating used for this shot."
+        },
+        "pellets": {
+            "type": "boolean",
+            "description": "Whether pellets were used as part of this shot."
+        },
+        "rmp_coil": {
+            "type": "boolean",
+            "description": "Whether an RMP coil was used as port of this shot."
+        },
+        "current_range": {
+            "type": "enum[string]",
+            "description": "The current range used for this shot. e.g. '7500 kA'"
+        },
+        "divertor_config": {
+            "type": "enum[string]",
+            "description": "The divertor configuration used for this shot. e.g. 'Super-X'"
+        },
+        "plasma_shape": {
+            "type": "enum[string]",
+            "description": "The plasma shape used for this shot. e.g. 'Connected Double Null'"
+        },
+        "comissioner": {
+            "type": "enum[string]",
+            "description": "The comissioner of this shot. e.g. 'UKAEA'"
+        },
+        "facility": {
+            "type": "enum[string]",
+            "description": "The facility (tokamak) that produced this shot. e.g. 'MAST'"
+        }
+    }
+}


### PR DESCRIPTION
Adding a first pass of a meta data schema for MAST diagnostic data based on our meta database.

These attributes are mostly derived from the names used in UDA and used in the MAST-U user pages.

I suggest that this PR is a place where we can start to discuss this schema more broadly.