### PR TITLE
Feature/update scicat mappings

### DIFF
--- a/ukaea-schema/facility/hive/scicat-mappings.json
+++ b/ukaea-schema/facility/hive/scicat-mappings.json
@@ -15,16 +15,16 @@
     "experimentType": "proposal.metadata.experimentType",
     "sampleCooling": "proposal.metadata.sampleCooling",
     "pulse": {
-        "pulseID": "dataset.scientificMetadata.pulseID",
-        "firstOperator": "dataset.scientificMetadata.firstOperator",
-        "secondOperator": "dataset.scientificMetadata.secondOperator",
-        "pulseStart": "dataset.scientificMetadata.pulseStart",
-        "pulseDuration": "dataset.scientificMetadata.pulseDuration",
-        "dataCaptureStart": "dataset.scientificMetadata.dataCaptureStart",
+        "pulseID": "dataset.scientificMetadata.pulseID.value",
+        "firstOperator": "dataset.scientificMetadata.firstOperator.value",
+        "secondOperator": "dataset.scientificMetadata.secondOperator.value",
+        "pulseStart": "dataset.scientificMetadata.pulseStart.value",
+        "pulseDuration": "dataset.scientificMetadata.pulseDuration.value",
+        "dataCaptureStart": "dataset.scientificMetadata.dataCaptureStart.value",
         "operatorComment": "dataset.comment",
-        "pulseQuality": "dataset.scientificMetadata.pulseQuality",
-        "coolantInformation": "dataset.scientificMetadata.coolantInformation",
-        "coilInformation": "dataset.scientificMetadata.coilInformation",
+        "pulseQuality": "dataset.scientificMetadata.pulseQuality.value",
+        "coolantInformation": "dataset.scientificMetadata.coolantInformation.value",
+        "coilInformation": "dataset.scientificMetadata.coilInformation.value",
         "diagnostics": [
             {
                 "diagnosticName": [


### PR DESCRIPTION
The schema for `scientificMetadata` in scicat requires that entries are of the form:

```json
{
  "yourLabel": {
    "value": 12,
    "units": "foo"
  }
}
```
(note: The `units` field is optional).

They can also be nested and contain multiple objects:
```json
{
  "yourGroup": {
    "yourLabel": {
      "value": 12,
      "units": "foo"
    },
    "yourOtherLabel": {
        "value": 42,
        "units": "bar"
    },
  }
}
```

For this reason, we have added `.value` to the mappings that are going into the `scientificMetadata` field.