### PR TITLE
fix: convert experimentNumber to string in jq mapping

### DIFF
--- a/metacat-mapping/forward-mapping/hive/dataset.jq
+++ b/metacat-mapping/forward-mapping/hive/dataset.jq
@@ -9,7 +9,7 @@
       "type": "raw",
       "sourceFolder": "/mnt/HIVE/E-\($parent.experimentNumber)/S-\($parent.sampleNumber)/P-\($parent.pulseNumber)",
       "description": $parent.comment,
-      "experimentNumber": $parent.experimentNumber,
+      "experimentNumber": "\($parent.experimentNumber)",
       "instrument": .,
       "additional": ($parent | del(.comment, .experimentNumber, .diagnostics, .schemaVersion, .pulseStartTimestamp))
   }

--- a/metacat-mapping/forward-mapping/hive/experiment.jq
+++ b/metacat-mapping/forward-mapping/hive/experiment.jq
@@ -1,6 +1,6 @@
 {
     "facility": "HIVE",
-    "facilityExperimentId": .experimentNumber,
+    "facilityExperimentId": "\(.experimentNumber)",
     "schemaVersion": .schemaVersion,
     "ownerGroup": "HIVE",
     "accessGroups": ["HIVE"],


### PR DESCRIPTION
this PR helps convert experimentNumber in dataset.jq and experiment.jq mapping file from number to string