### PR TITLE
minor changes to align mrf forward mappings

### DIFF
--- a/metacat-mapping/forward-mapping/mrf/dataset.jq
+++ b/metacat-mapping/forward-mapping/mrf/dataset.jq
@@ -1,13 +1,13 @@
 {
-  "contactEmail": (.internalUser[0].email // .scientificSupport[0].email?),
+  "contactEmail": (.scientificSupport[0].email // .internalUser[0].email?),
   "creationTime" : .bookingStart,
   "type": "raw",
-  "sourceFolder": "/mnt/MRF/\(.jobId)/\(.seid)/\(.sessionId)",
-  "description": .notes,
+  "sourceFolder": "/mnt/MRF/\(.jobId)/\(.seId)/\(.sessionId)",
+  "description": "",
   "experimentNumber": "\(.jobId)-\(.sessionId)",
-  "instrument": [.seid],
+  "instrument": [.seId],
   "schemaVersion": (.schemaVersion // "1.0.0"),
   "ownerGroup": "MRF",
   "accessGroups": "[MRF]",
-  "additional": (. | del(.notes, .seid, .bookingStart, .jobId, .sessionId))
+  "additional": (. | del(.seId, .bookingStart, .jobId, .sessionId, .schemaVersion))
 }

--- a/metacat-mapping/forward-mapping/mrf/instrument.jq
+++ b/metacat-mapping/forward-mapping/mrf/instrument.jq
@@ -1,6 +1,6 @@
 {
-  "instrumentId": .seid,
-  "seidDescription": .seidDescription
+  "instrumentId": .seId,
+  "seidDescription": .seIdDescription
   "schemaVersion": (.schemaVersion // "1.0.0"),
   "ownerGroup": "MRF",
   "accessGroups": "[MRF]",


### PR DESCRIPTION
As per discussion:

- `seid` --> `seId`
- `description` no longer mapped to `notes`, `description` now empty string and `notes` now included in `additional`.